### PR TITLE
fix gitignore to exclude node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/node_modules/
+node_modules/
 
 
 .DS_Store


### PR DESCRIPTION
Actuellement le fichier node_modules n'est pas ignoré par git : https://github.com/friarobaz/ecole-escalade-2022/tree/main/node_modules
